### PR TITLE
Switch Sheets deletion OAuth to PKCE flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@ Cette extension Chrome permet de récupérer la liste des devis depuis Google Sh
 
 1. Les constantes `GOOGLE_SHEETS_API_KEY`, `SPREADSHEET_ID` et `QUOTES_RANGE` sont renseignées dans `background.js`.
    Adaptez-les si la source Google Sheets change.
-2. Créez un identifiant client OAuth 2.0 de type « Application Web » dans Google Cloud
-   (ou mettez à jour un identifiant existant) puis remplacez
-   `REPLACE_WITH_OAUTH_CLIENT_ID.apps.googleusercontent.com` dans `manifest.json` par
-   la valeur exacte fournie par Google. Ajoutez l’URL de redirection
-   `https://<ID_DE_L_EXTENSION>.chromiumapp.org/` (remplacez `<ID_DE_L_EXTENSION>` par
-   l’identifiant visible dans `chrome://extensions`) et autorisez le scope
-   `https://www.googleapis.com/auth/spreadsheets`.
+2. Créez un identifiant client OAuth 2.0 de type « Chrome App » dans Google Cloud
+   en renseignant l’identifiant de l’extension (visible dans `chrome://extensions`).
+   Remplacez ensuite `REPLACE_WITH_OAUTH_CLIENT_ID.apps.googleusercontent.com`
+   dans `manifest.json` par la valeur exacte fournie et assurez-vous que le scope
+   `https://www.googleapis.com/auth/spreadsheets` est bien déclaré.
 3. Lors du premier clic sur « Supprimer les devis utilisés », Chrome affichera une
    fenêtre d’autorisation Google permettant de consentir à l’accès en écriture à la
    feuille. Validez-la pour que la suppression des lignes fonctionne.
@@ -25,8 +23,8 @@ Si un message mentionne un « client OAuth invalide » ou « bad client id �
 1. Vérifiez que le champ `oauth2.client_id` du `manifest.json` contient bien l’identifiant
    complet se terminant par `.apps.googleusercontent.com` fourni par Google Cloud (et non
    la valeur par défaut du dépôt).
-2. Assurez-vous que l’identifiant est de type « Application Web » et que la redirection
-   `https://<ID_DE_L_EXTENSION>.chromiumapp.org/` est déclarée dans Google Cloud.
+2. Assurez-vous que l’identifiant est bien de type « Chrome App » et qu’il fait
+   référence à l’identifiant exact de l’extension dans Google Cloud.
 3. Rechargez l’extension puis relancez la suppression. Chrome doit éventuellement afficher
    la fenêtre d’autorisation si nécessaire.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Yooliz Auto-Fill Extension
+
+Cette extension Chrome permet de récupérer la liste des devis depuis Google Sheets et de pré-remplir le formulaire Yooliz.
+
+## Configuration
+
+1. Les constantes `GOOGLE_SHEETS_API_KEY`, `SPREADSHEET_ID` et `QUOTES_RANGE` sont renseignées dans `background.js`.
+   Adaptez-les si la source Google Sheets change.
+2. Créez un identifiant client OAuth 2.0 de type « Application Web » dans Google Cloud
+   (ou mettez à jour un identifiant existant) puis remplacez
+   `REPLACE_WITH_OAUTH_CLIENT_ID.apps.googleusercontent.com` dans `manifest.json` par
+   la valeur exacte fournie par Google. Ajoutez l’URL de redirection
+   `https://<ID_DE_L_EXTENSION>.chromiumapp.org/` (remplacez `<ID_DE_L_EXTENSION>` par
+   l’identifiant visible dans `chrome://extensions`) et autorisez le scope
+   `https://www.googleapis.com/auth/spreadsheets`.
+3. Lors du premier clic sur « Supprimer les devis utilisés », Chrome affichera une
+   fenêtre d’autorisation Google permettant de consentir à l’accès en écriture à la
+   feuille. Validez-la pour que la suppression des lignes fonctionne.
+4. Rechargez l’extension dans Chrome après toute modification.
+
+### Dépannage OAuth
+
+Si un message mentionne un « client OAuth invalide » ou « bad client id » dans le popup :
+
+1. Vérifiez que le champ `oauth2.client_id` du `manifest.json` contient bien l’identifiant
+   complet se terminant par `.apps.googleusercontent.com` fourni par Google Cloud (et non
+   la valeur par défaut du dépôt).
+2. Assurez-vous que l’identifiant est de type « Application Web » et que la redirection
+   `https://<ID_DE_L_EXTENSION>.chromiumapp.org/` est déclarée dans Google Cloud.
+3. Rechargez l’extension puis relancez la suppression. Chrome doit éventuellement afficher
+   la fenêtre d’autorisation si nécessaire.
+
+## Utilisation
+
+1. Ouvrez la page Yooliz « Créer un devis ».
+2. Ouvrez le popup de l’extension : la liste des devis est chargée depuis Google Sheets.
+   L’interface se synchronise automatiquement toutes les quelques secondes pour
+   refléter les ajouts, suppressions ou modifications dans le fichier Google Sheets.
+3. Cliquez sur « Remplir » pour injecter les informations du devis sélectionné dans le formulaire.
+
+Lorsque Google Sheets ne contient aucune ligne fournisseur, aucun devis n’est
+proposé dans l’interface. Dès qu’une nouvelle ligne est ajoutée dans la feuille,
+elle apparaît automatiquement dans la liste sans recharger l’extension.
+
+Lorsqu’un devis fournisseur est supprimé via « Supprimer les devis utilisés », l’extension appelle directement
+l’API Google Sheets en utilisant l’autorisation OAuth 2.0 accordée pour effacer les lignes correspondantes.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,948 @@
+const GOOGLE_SHEETS_API_KEY = "AIzaSyAfy-Lq0veFj7v2oUZXSZbdOSn8pdOOTmY";
+const SPREADSHEET_ID = "1wGfG-tNnxo17dnaQItdvAmrmcYm-2ofRcKmFQ2CI198";
+const QUOTES_RANGE = "Sheet1!A1:Z";
+const CACHE_DURATION_MS = 5 * 60 * 1000;
+const SHEET_METADATA_CACHE_DURATION_MS = 60 * 60 * 1000;
+const SHEETS_WRITE_SCOPE = "https://www.googleapis.com/auth/spreadsheets";
+const OAUTH_CLIENT_ID_PLACEHOLDER =
+  "REPLACE_WITH_OAUTH_CLIENT_ID.apps.googleusercontent.com";
+const OAUTH_TOKEN_STORAGE_KEY = "googleSheetsOAuthTokens";
+const TOKEN_EXPIRY_MARGIN_MS = 60 * 1000;
+const GOOGLE_AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+
+const getConfiguredOAuthClientId = () => {
+  try {
+    const manifest = chrome?.runtime?.getManifest
+      ? chrome.runtime.getManifest()
+      : null;
+    const manifestClientId = manifest?.oauth2?.client_id;
+    return typeof manifestClientId === "string" ? manifestClientId.trim() : "";
+  } catch (error) {
+    console.warn("[Background] Impossible de lire la configuration OAuth", error);
+    return "";
+  }
+};
+
+const normalizeOAuthErrorMessage = (message) => {
+  if (!message) {
+    return "";
+  }
+
+  const normalized = message.toLowerCase();
+
+  if (normalized.includes("invalid_client") || normalized.includes("bad client id")) {
+    return (
+      "Client OAuth Google invalide. Vérifiez que manifest.json contient " +
+      "l'identifiant OAuth 2.0 exact fourni par Google Cloud."
+    );
+  }
+
+  if (normalized.includes("redirect_uri_mismatch")) {
+    const extensionId = chrome?.runtime?.id;
+    const redirectUri = extensionId
+      ? `https://${extensionId}.chromiumapp.org/`
+      : "https://<extension-id>.chromiumapp.org/";
+
+    return (
+      "Configuration OAuth incomplète. Ajoutez l'URL de redirection " +
+      `${redirectUri} au client OAuth Google.`
+    );
+  }
+
+  if (normalized.includes("access_denied")) {
+    return "Autorisation Google Sheets annulée ou refusée par l'utilisateur.";
+  }
+
+  return message;
+};
+
+const ensureSheetsOAuthConfigured = () => {
+  if (!chrome?.identity?.launchWebAuthFlow) {
+    throw new Error(
+      `La suppression des devis nécessite la permission Chrome Identity et un client OAuth valide (${SHEETS_WRITE_SCOPE}). Vérifiez la configuration dans manifest.json.`
+    );
+  }
+
+  const clientId = getConfiguredOAuthClientId();
+
+  if (!clientId) {
+    throw new Error(
+      "Client OAuth Google manquant. Déclarez un identifiant OAuth 2.0 valide dans manifest.json."
+    );
+  }
+
+  if (clientId === OAUTH_CLIENT_ID_PLACEHOLDER) {
+    throw new Error(
+      "Client OAuth Google non configuré. Remplacez l'identifiant par défaut dans manifest.json par celui fourni par Google Cloud."
+    );
+  }
+
+  return clientId;
+};
+
+const readStoredOAuthTokens = () =>
+  new Promise((resolve) => {
+    chrome.storage?.local?.get
+      ? chrome.storage.local.get([OAUTH_TOKEN_STORAGE_KEY], (items) => {
+          if (chrome.runtime.lastError) {
+            console.warn(
+              "[Background] Lecture des jetons OAuth impossible",
+              chrome.runtime.lastError
+            );
+            resolve(null);
+            return;
+          }
+
+          resolve(items?.[OAUTH_TOKEN_STORAGE_KEY] || null);
+        })
+      : resolve(null);
+  });
+
+const writeStoredOAuthTokens = (tokens) =>
+  new Promise((resolve, reject) => {
+    if (!chrome?.storage?.local?.set) {
+      resolve();
+      return;
+    }
+
+    chrome.storage.local.set({ [OAUTH_TOKEN_STORAGE_KEY]: tokens }, () => {
+      if (chrome.runtime.lastError) {
+        reject(chrome.runtime.lastError);
+        return;
+      }
+
+      resolve();
+    });
+  });
+
+const clearStoredOAuthTokens = () =>
+  new Promise((resolve) => {
+    if (!chrome?.storage?.local?.remove) {
+      resolve();
+      return;
+    }
+
+    chrome.storage.local.remove(OAUTH_TOKEN_STORAGE_KEY, () => {
+      if (chrome.runtime.lastError) {
+        console.warn(
+          "[Background] Impossible d'effacer les jetons OAuth",
+          chrome.runtime.lastError
+        );
+      }
+
+      resolve();
+    });
+  });
+
+const base64UrlEncode = (arrayBuffer) => {
+  const uint8Array =
+    arrayBuffer instanceof Uint8Array ? arrayBuffer : new Uint8Array(arrayBuffer);
+
+  let binary = "";
+  uint8Array.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+};
+
+const generateRandomBytes = (length = 32) => {
+  const buffer = new Uint8Array(length);
+  crypto.getRandomValues(buffer);
+  return buffer;
+};
+
+const generateCodeVerifier = () => base64UrlEncode(generateRandomBytes(64));
+
+const generateState = () => base64UrlEncode(generateRandomBytes(32));
+
+const generateCodeChallenge = async (codeVerifier) => {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(codeVerifier);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return base64UrlEncode(new Uint8Array(digest));
+};
+
+const parseTokenPayload = (payload, fallbackRefreshToken = null) => {
+  if (!payload?.access_token) {
+    throw new Error("Réponse OAuth invalide : access_token manquant.");
+  }
+
+  const expiresIn = Number(payload.expires_in);
+  const expiresAt = Date.now() + (Number.isFinite(expiresIn) ? expiresIn : 3600) * 1000;
+
+  return {
+    accessToken: payload.access_token,
+    tokenType: payload.token_type || "Bearer",
+    expiresAt,
+    refreshToken: payload.refresh_token || fallbackRefreshToken || null,
+    scope: payload.scope || SHEETS_WRITE_SCOPE,
+  };
+};
+
+const exchangeAuthCodeForTokens = async ({
+  code,
+  codeVerifier,
+  redirectUri,
+  clientId,
+}) => {
+  const body = new URLSearchParams({
+    code,
+    client_id: clientId,
+    code_verifier: codeVerifier,
+    redirect_uri: redirectUri,
+    grant_type: "authorization_code",
+  });
+
+  const response = await fetch(GOOGLE_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => null);
+    const message =
+      errorBody?.error_description ||
+      errorBody?.error ||
+      `Échec de l'échange du code OAuth (${response.status}).`;
+    throw new Error(normalizeOAuthErrorMessage(message));
+  }
+
+  const payload = await response.json();
+  return parseTokenPayload(payload);
+};
+
+const refreshAccessToken = async ({ clientId, refreshToken }) => {
+  const body = new URLSearchParams({
+    client_id: clientId,
+    refresh_token: refreshToken,
+    grant_type: "refresh_token",
+  });
+
+  const response = await fetch(GOOGLE_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => null);
+    const errorMessage =
+      errorBody?.error_description ||
+      errorBody?.error ||
+      `Échec du rafraîchissement du jeton OAuth (${response.status}).`;
+    throw new Error(normalizeOAuthErrorMessage(errorMessage));
+  }
+
+  const payload = await response.json();
+  return parseTokenPayload(payload, refreshToken);
+};
+
+const getRedirectUri = () => {
+  try {
+    return chrome.identity.getRedirectURL("oauth2");
+  } catch (error) {
+    console.warn("[Background] Utilisation du redirect URL par défaut", error);
+    return chrome.identity.getRedirectURL();
+  }
+};
+
+const createInteractionRequiredError = (message) => {
+  const error = new Error(message);
+  error.code = "OAUTH_INTERACTION_REQUIRED";
+  return error;
+};
+
+const needsInteractiveAuthorization = (error) =>
+  error?.code === "OAUTH_INTERACTION_REQUIRED";
+
+let interactiveAuthPromise = null;
+
+const runInteractiveOAuthFlow = async (clientId) => {
+  if (interactiveAuthPromise) {
+    return interactiveAuthPromise;
+  }
+
+  interactiveAuthPromise = (async () => {
+    const redirectUri = getRedirectUri();
+    const codeVerifier = generateCodeVerifier();
+    const codeChallenge = await generateCodeChallenge(codeVerifier);
+    const state = generateState();
+
+    const authUrl = new URL(GOOGLE_AUTH_ENDPOINT);
+    authUrl.searchParams.set("client_id", clientId);
+    authUrl.searchParams.set("response_type", "code");
+    authUrl.searchParams.set("redirect_uri", redirectUri);
+    authUrl.searchParams.set("scope", SHEETS_WRITE_SCOPE);
+    authUrl.searchParams.set("access_type", "offline");
+    authUrl.searchParams.set("prompt", "consent");
+    authUrl.searchParams.set("include_granted_scopes", "true");
+    authUrl.searchParams.set("state", state);
+    authUrl.searchParams.set("code_challenge", codeChallenge);
+    authUrl.searchParams.set("code_challenge_method", "S256");
+
+    const redirectResponse = await new Promise((resolve, reject) => {
+      chrome.identity.launchWebAuthFlow(
+        {
+          url: authUrl.toString(),
+          interactive: true,
+        },
+        (redirectUrl) => {
+          if (chrome.runtime.lastError) {
+            reject(
+              new Error(
+                normalizeOAuthErrorMessage(
+                  chrome.runtime.lastError.message ||
+                    "Échec de l'authentification Google."
+                )
+              )
+            );
+            return;
+          }
+
+          if (!redirectUrl) {
+            reject(new Error("Réponse OAuth vide."));
+            return;
+          }
+
+          resolve(redirectUrl);
+        }
+      );
+    });
+
+    let parsedUrl;
+
+    try {
+      parsedUrl = new URL(redirectResponse);
+    } catch (error) {
+      throw new Error("Réponse OAuth invalide.");
+    }
+
+    const returnedState = parsedUrl.searchParams.get("state");
+
+    if (!returnedState || returnedState !== state) {
+      throw new Error("Réponse OAuth inattendue (state incohérent).");
+    }
+
+    const errorParam = parsedUrl.searchParams.get("error");
+
+    if (errorParam) {
+      throw new Error(normalizeOAuthErrorMessage(errorParam));
+    }
+
+    const authCode = parsedUrl.searchParams.get("code");
+
+    if (!authCode) {
+      throw new Error("Code d'autorisation Google absent de la réponse OAuth.");
+    }
+
+    const tokens = await exchangeAuthCodeForTokens({
+      code: authCode,
+      codeVerifier,
+      redirectUri,
+      clientId,
+    });
+
+    await writeStoredOAuthTokens(tokens);
+
+    return tokens;
+  })()
+    .catch(async (error) => {
+      await clearStoredOAuthTokens();
+      throw error;
+    })
+    .finally(() => {
+      interactiveAuthPromise = null;
+    });
+
+  return interactiveAuthPromise;
+};
+
+const getValidAccessToken = async ({ interactive = false } = {}) => {
+  const clientId = ensureSheetsOAuthConfigured();
+  const storedTokens = await readStoredOAuthTokens();
+  const now = Date.now();
+
+  if (
+    storedTokens?.accessToken &&
+    typeof storedTokens?.expiresAt === "number" &&
+    storedTokens.expiresAt - TOKEN_EXPIRY_MARGIN_MS > now
+  ) {
+    return storedTokens;
+  }
+
+  if (storedTokens?.refreshToken) {
+    try {
+      const refreshed = await refreshAccessToken({
+        clientId,
+        refreshToken: storedTokens.refreshToken,
+      });
+      await writeStoredOAuthTokens(refreshed);
+      return refreshed;
+    } catch (error) {
+      console.warn("[Background] Rafraîchissement OAuth échoué", error);
+      await clearStoredOAuthTokens();
+
+      if (!interactive) {
+        throw createInteractionRequiredError(
+          normalizeOAuthErrorMessage(error?.message) ||
+            "Authentification Google Sheets requise."
+        );
+      }
+    }
+  }
+
+  if (!interactive) {
+    throw createInteractionRequiredError("Authentification Google Sheets requise.");
+  }
+
+  return runInteractiveOAuthFlow(clientId);
+};
+
+const performAuthorizedSheetsRequest = async ({
+  url,
+  method = "GET",
+  body,
+  headers = {},
+}) => {
+  const attempt = async (interactive) => {
+    let tokens;
+
+    try {
+      tokens = await getValidAccessToken({ interactive });
+    } catch (tokenError) {
+      if (!interactive && needsInteractiveAuthorization(tokenError)) {
+        return attempt(true);
+      }
+
+      throw tokenError;
+    }
+
+    const response = await fetch(url, {
+      method,
+      headers: {
+        ...headers,
+        Authorization: `${tokens.tokenType || "Bearer"} ${tokens.accessToken}`,
+      },
+      body,
+    });
+
+    if (response.status === 401) {
+      await clearStoredOAuthTokens();
+
+      if (!interactive) {
+        return attempt(true);
+      }
+
+      const errorBody = await response.text().catch(() => "");
+      let details = "";
+
+      if (errorBody) {
+        try {
+          const parsed = JSON.parse(errorBody);
+          const message = parsed?.error?.message;
+          details = message ? ` ${message}` : ` Réponse: ${errorBody}`;
+        } catch (parseError) {
+          details = ` Réponse: ${errorBody}`;
+        }
+      }
+
+      throw new Error(
+        `Authentification Google Sheets requise (${response.status}).${details}`
+      );
+    }
+
+    return response;
+  };
+
+  return attempt(false);
+};
+
+let registeredYoolizTabId = null;
+
+const storageSession = chrome.storage?.session;
+const STORAGE_KEYS = {
+  registeredTabId: "registeredYoolizTabId",
+};
+
+const persistRegisteredTabId = (tabId) =>
+  new Promise((resolve) => {
+    if (!storageSession) {
+      registeredYoolizTabId = tabId;
+      resolve();
+      return;
+    }
+
+    if (typeof tabId === "number") {
+      storageSession.set({ [STORAGE_KEYS.registeredTabId]: tabId }, () => {
+        if (chrome.runtime.lastError) {
+          console.warn(
+            "[Background] Échec de la persistance de l'onglet Yooliz",
+            chrome.runtime.lastError
+          );
+        }
+
+        registeredYoolizTabId = tabId;
+        resolve();
+      });
+      return;
+    }
+
+    storageSession.remove(STORAGE_KEYS.registeredTabId, () => {
+      if (chrome.runtime.lastError) {
+        console.warn(
+          "[Background] Échec de la suppression de l'onglet stocké",
+          chrome.runtime.lastError
+        );
+      }
+
+      registeredYoolizTabId = null;
+      resolve();
+    });
+  });
+
+const restoreRegisteredTabId = () => {
+  if (!storageSession) {
+    return;
+  }
+
+  storageSession.get(STORAGE_KEYS.registeredTabId, (result) => {
+    if (chrome.runtime.lastError) {
+      console.warn(
+        "[Background] Impossible de restaurer l'onglet Yooliz",
+        chrome.runtime.lastError
+      );
+      return;
+    }
+
+    const storedTabId = result?.[STORAGE_KEYS.registeredTabId];
+
+    if (typeof storedTabId === "number") {
+      registeredYoolizTabId = storedTabId;
+      console.log("[Background] Onglet Yooliz restauré", storedTabId);
+    }
+  });
+};
+
+restoreRegisteredTabId();
+
+let cachedQuotes = [];
+let lastFetchTimestamp = 0;
+let cachedSheetId = null;
+let sheetIdFetchedAt = 0;
+
+const HEADER_ALIASES = {
+  id: ["id", "numero", "numero_devis", "num_devis", "devis", "id_devis"],
+  label: ["libelle", "nom", "description", "titre", "intitule"],
+  make: ["marque", "make"],
+  model: ["modele", "model"],
+  engine: ["motorisation", "engine", "finition"],
+  fuelType: ["carburant", "fuel", "fueltype", "energie"],
+  usageType: ["usage", "usage_type", "type_usage"],
+  vehicleType: ["type_vehicule", "vehicule_type", "typevehicule", "type"],
+  vehicleCategory: [
+    "categorie",
+    "categorie_vehicule",
+    "vehicle_category",
+    "categorie_vehicule",
+    "categorievehicule",
+  ],
+};
+
+const normalizeHeader = (header = "") =>
+  header
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+const findValueByAliases = (rowObject, aliases = []) => {
+  for (const alias of aliases) {
+    if (rowObject[alias]) {
+      return rowObject[alias];
+    }
+  }
+
+  return "";
+};
+
+const transformRowToQuote = (rowObject, index) => {
+  const quote = {
+    id: findValueByAliases(rowObject, HEADER_ALIASES.id) || `devis-${index + 1}`,
+    label:
+      findValueByAliases(rowObject, HEADER_ALIASES.label) ||
+      findValueByAliases(rowObject, HEADER_ALIASES.id) ||
+      `Devis ${index + 1}`,
+    make: findValueByAliases(rowObject, HEADER_ALIASES.make),
+    model: findValueByAliases(rowObject, HEADER_ALIASES.model),
+    engine: findValueByAliases(rowObject, HEADER_ALIASES.engine),
+    fuelType: findValueByAliases(rowObject, HEADER_ALIASES.fuelType),
+    usageType: findValueByAliases(rowObject, HEADER_ALIASES.usageType),
+    vehicleType: findValueByAliases(rowObject, HEADER_ALIASES.vehicleType),
+    vehicleCategory: findValueByAliases(rowObject, HEADER_ALIASES.vehicleCategory),
+    raw: rowObject,
+    rowNumber: index + 2,
+  };
+
+  return quote;
+};
+
+const buildQuotesFromSheetData = (values = []) => {
+  if (!Array.isArray(values) || values.length === 0) {
+    return [];
+  }
+
+  const [headerRow, ...dataRows] = values;
+  const normalizedHeaders = headerRow.map((header) => normalizeHeader(header));
+
+  return dataRows.map((row, rowIndex) => {
+    const rowObject = {};
+
+    normalizedHeaders.forEach((headerKey, cellIndex) => {
+      if (!headerKey) {
+        return;
+      }
+
+      rowObject[headerKey] = row[cellIndex] ?? "";
+    });
+
+    return transformRowToQuote(rowObject, rowIndex);
+  });
+};
+
+const fetchQuotesFromSheet = async () => {
+  if (!GOOGLE_SHEETS_API_KEY || !SPREADSHEET_ID) {
+    throw new Error("La configuration Google Sheets est incomplète.");
+  }
+
+  const baseUrl = `https://sheets.googleapis.com/v4/spreadsheets/${SPREADSHEET_ID}/values/${encodeURIComponent(
+    QUOTES_RANGE
+  )}`;
+
+  const url = `${baseUrl}?key=${GOOGLE_SHEETS_API_KEY}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Erreur API Google Sheets (${response.status}): ${errorBody}`);
+  }
+
+  const data = await response.json();
+  return buildQuotesFromSheetData(data.values);
+};
+
+const getQuotes = async ({ forceRefresh = false } = {}) => {
+  const now = Date.now();
+  const isCacheValid = now - lastFetchTimestamp < CACHE_DURATION_MS;
+
+  if (!forceRefresh && isCacheValid && cachedQuotes.length > 0) {
+    return { quotes: cachedQuotes, fromCache: true };
+  }
+
+  const quotes = await fetchQuotesFromSheet();
+
+  cachedQuotes = quotes;
+  lastFetchTimestamp = now;
+
+  return { quotes, fromCache: false };
+};
+
+const getSheetTitleFromRange = () => {
+  if (!QUOTES_RANGE) {
+    return null;
+  }
+
+  const [rawSheetTitle] = QUOTES_RANGE.split("!");
+
+  if (!rawSheetTitle) {
+    return null;
+  }
+
+  const trimmed = rawSheetTitle.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.startsWith("'") && trimmed.endsWith("'") && trimmed.length >= 2) {
+    return trimmed.slice(1, -1);
+  }
+
+  return trimmed;
+};
+
+const fetchSheetId = async () => {
+  if (!GOOGLE_SHEETS_API_KEY || !SPREADSHEET_ID) {
+    throw new Error("La configuration Google Sheets est incomplète.");
+  }
+
+  const sheetTitle = getSheetTitleFromRange();
+
+  if (!sheetTitle) {
+    throw new Error(
+      "Impossible de déterminer l'onglet cible à partir de QUOTES_RANGE."
+    );
+  }
+
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${SPREADSHEET_ID}?fields=sheets.properties(sheetId,title)&key=${GOOGLE_SHEETS_API_KEY}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(
+      `Erreur lors de la récupération des métadonnées de la feuille (${response.status}): ${errorBody}`
+    );
+  }
+
+  const data = await response.json();
+  const sheets = Array.isArray(data?.sheets) ? data.sheets : [];
+
+  const matchingSheet = sheets.find((sheet) => {
+    const title = sheet?.properties?.title;
+    return typeof title === "string" && title === sheetTitle;
+  });
+
+  const sheetId = matchingSheet?.properties?.sheetId;
+
+  if (typeof sheetId !== "number") {
+    throw new Error(
+      `Aucun onglet nommé « ${sheetTitle} » n'a été trouvé dans la feuille Google Sheets.`
+    );
+  }
+
+  cachedSheetId = sheetId;
+  sheetIdFetchedAt = Date.now();
+
+  return sheetId;
+};
+
+const getSheetId = async () => {
+  const now = Date.now();
+
+  if (
+    typeof cachedSheetId === "number" &&
+    now - sheetIdFetchedAt < SHEET_METADATA_CACHE_DURATION_MS
+  ) {
+    return cachedSheetId;
+  }
+
+  return fetchSheetId();
+};
+
+const deleteRowsFromSheet = async (rowNumbers = []) => {
+  const normalizedRows = rowNumbers
+    .map((rowNumber) => Number(rowNumber))
+    .filter((rowNumber) => Number.isInteger(rowNumber) && rowNumber > 1);
+
+  const uniqueRows = Array.from(new Set(normalizedRows));
+
+  if (uniqueRows.length === 0) {
+    return { success: true, removed: 0 };
+  }
+
+  const sheetId = await getSheetId();
+
+  const requests = uniqueRows
+    .sort((a, b) => b - a)
+    .map((rowNumber) => ({
+      deleteDimension: {
+        range: {
+          sheetId,
+          dimension: "ROWS",
+          startIndex: rowNumber - 1,
+          endIndex: rowNumber,
+        },
+      },
+    }));
+
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${SPREADSHEET_ID}:batchUpdate`;
+
+  const response = await performAuthorizedSheetsRequest({
+    url,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ requests }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(
+      `Erreur lors de la suppression des lignes Google Sheets (${response.status}): ${errorBody}`
+    );
+  }
+
+  return { success: true, removed: uniqueRows.length };
+};
+
+const deleteQuotesFromSheet = async (quotes = []) => {
+  if (!Array.isArray(quotes) || quotes.length === 0) {
+    return { success: true, removed: 0 };
+  }
+
+  const rowNumbers = quotes.map((quote) => quote?.rowNumber);
+
+  if (rowNumbers.length === 0) {
+    return { success: true, removed: 0 };
+  }
+
+  return deleteRowsFromSheet(rowNumbers);
+};
+
+const removeQuotesFromCache = (quotes = []) => {
+  if (!Array.isArray(quotes) || quotes.length === 0) {
+    return;
+  }
+
+  const ids = new Set();
+  const rowNumbers = new Set();
+
+  quotes.forEach((quote) => {
+    if (quote?.id) {
+      ids.add(String(quote.id));
+    }
+
+    if (typeof quote?.rowNumber === "number") {
+      rowNumbers.add(quote.rowNumber);
+    }
+  });
+
+  cachedQuotes = cachedQuotes.filter((quote) => {
+    const matchesId = quote?.id && ids.has(String(quote.id));
+    const matchesRow = typeof quote?.rowNumber === "number" && rowNumbers.has(quote.rowNumber);
+    return !matchesId && !matchesRow;
+  });
+
+  lastFetchTimestamp = 0;
+};
+
+const sendQuoteToContentScript = (payload) =>
+  new Promise((resolve, reject) => {
+    if (typeof registeredYoolizTabId !== "number") {
+      reject(new Error("Aucun onglet Yooliz enregistré."));
+      return;
+    }
+
+    try {
+      chrome.tabs.sendMessage(
+        registeredYoolizTabId,
+        {
+          action: "fillForm",
+          data: payload,
+        },
+        (response) => {
+          if (chrome.runtime.lastError) {
+            const lastErrorMessage = chrome.runtime.lastError.message || "Échec de l'envoi au contenu.";
+
+            if (lastErrorMessage.includes("No tab with id")) {
+              persistRegisteredTabId(null);
+            }
+
+            reject(new Error(lastErrorMessage));
+            return;
+          }
+
+          if (response?.success === false) {
+            reject(new Error(response?.error || "Le contenu a signalé un échec."));
+            return;
+          }
+
+          resolve(response);
+        }
+      );
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message?.action === "registerContentTab") {
+    const tabId = sender?.tab?.id;
+
+    if (typeof tabId === "number") {
+      persistRegisteredTabId(tabId).then(() => {
+        console.log("[Background] Onglet Yooliz enregistré", tabId);
+        sendResponse({ success: true });
+      });
+      return true;
+    }
+
+    sendResponse({ success: false, error: "Impossible d'identifier l'onglet du contenu." });
+    return false;
+  }
+
+  if (message?.action === "fillQuote") {
+    console.log("[Background] Requête de remplissage reçue", message.quoteId || "(sans identifiant)");
+    if (!message?.data || typeof message.data !== "object") {
+      sendResponse({ success: false, error: "Données de devis invalides." });
+      return false;
+    }
+
+    if (typeof registeredYoolizTabId !== "number") {
+      persistRegisteredTabId(null);
+      sendResponse({ success: false, error: "Aucun onglet Yooliz prêt à recevoir les données." });
+      return false;
+    }
+
+    sendQuoteToContentScript(message.data)
+      .then((response) => {
+        sendResponse({ success: true, response });
+      })
+      .catch((error) => {
+        console.error("[Background] Erreur lors de l'envoi du devis au contenu", error);
+        sendResponse({ success: false, error: error.message });
+      });
+
+    return true;
+  }
+
+  if (message?.action === "getQuotes") {
+    const forceRefresh = Boolean(message?.forceRefresh);
+
+    getQuotes({ forceRefresh })
+      .then((result) => {
+        sendResponse({ success: true, quotes: result.quotes, fromCache: result.fromCache });
+      })
+      .catch((error) => {
+        console.error("[Background] Erreur lors de la récupération des devis", error);
+        sendResponse({ success: false, error: error.message });
+      });
+
+    return true;
+  }
+
+  if (message?.action === "removeUsedQuotes") {
+    const quotesToRemove = Array.isArray(message?.quotes) ? message.quotes : [];
+
+    deleteQuotesFromSheet(quotesToRemove)
+      .then((result) => {
+        removeQuotesFromCache(quotesToRemove);
+        sendResponse({ success: true, removed: result.removed });
+      })
+      .catch((error) => {
+        console.error(
+          "[Background] Erreur lors de la suppression des lignes Google Sheets",
+          error
+        );
+        sendResponse({ success: false, error: error.message });
+      });
+
+    return true;
+  }
+
+  return undefined;
+});

--- a/content.js
+++ b/content.js
@@ -1,0 +1,414 @@
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const DEFAULT_WAIT_OPTIONS = { timeout: 5000, interval: 50 };
+
+const log = (message, extra) => {
+  if (extra !== undefined) {
+    console.log(`[Content] ${message}`, extra);
+  } else {
+    console.log(`[Content] ${message}`);
+  }
+};
+
+const waitForElement = (selector, { timeout = 5000, interval = 100 } = {}) =>
+  new Promise((resolve) => {
+    const startTime = Date.now();
+
+    const checkElement = () => {
+      const element = document.querySelector(selector);
+
+      if (element) {
+        resolve(element);
+        return;
+      }
+
+      if (Date.now() - startTime >= timeout) {
+        resolve(null);
+        return;
+      }
+
+      setTimeout(checkElement, interval);
+    };
+
+    checkElement();
+  });
+
+const triggerEvents = (element, events) => {
+  events.forEach((eventName) => {
+    element.dispatchEvent(new Event(eventName, { bubbles: true }));
+  });
+};
+
+const waitForSelectorsOrLabel = async (
+  selectors = [],
+  labelText,
+  options = DEFAULT_WAIT_OPTIONS
+) => {
+  const uniqueSelectors = Array.from(
+    new Set(selectors.filter((selector) => typeof selector === "string" && selector))
+  );
+
+  const tryResolve = () => {
+    for (const selector of uniqueSelectors) {
+      try {
+        const element = document.querySelector(selector);
+        if (element) {
+          return element;
+        }
+      } catch (error) {
+        log(`Invalid selector skipped: ${selector}`, error);
+      }
+    }
+
+    if (labelText) {
+      const control = findElementByLabelText(labelText);
+      if (control) {
+        return control;
+      }
+    }
+
+    return null;
+  };
+
+  const immediateMatch = tryResolve();
+  if (immediateMatch) {
+    return immediateMatch;
+  }
+
+  const startTime = Date.now();
+  while (Date.now() - startTime < options.timeout) {
+    await delay(options.interval);
+    const nextMatch = tryResolve();
+    if (nextMatch) {
+      return nextMatch;
+    }
+  }
+
+  return null;
+};
+
+const normalizeText = (text = "") =>
+  text
+    .toString()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const findElementByLabelText = (labelText) => {
+  if (!labelText) {
+    return null;
+  }
+
+  const normalizedTarget = normalizeText(labelText);
+
+  const labels = Array.from(document.querySelectorAll("label"));
+  for (const label of labels) {
+    const normalizedLabel = normalizeText(label.textContent || "");
+
+    if (!normalizedLabel || !normalizedLabel.includes(normalizedTarget)) {
+      continue;
+    }
+
+    if (label.htmlFor) {
+      const control = document.getElementById(label.htmlFor);
+      if (control) {
+        return control;
+      }
+    }
+
+    const fallbackControl = label.querySelector("input, select, textarea");
+    if (fallbackControl) {
+      return fallbackControl;
+    }
+  }
+
+  return null;
+};
+
+const waitForLabelElement = async (labelText, options = DEFAULT_WAIT_OPTIONS) => {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < options.timeout) {
+    const control = findElementByLabelText(labelText);
+    if (control) {
+      return control;
+    }
+
+    await delay(options.interval);
+  }
+
+  return null;
+};
+
+const resolveElementTarget = async (target, options = DEFAULT_WAIT_OPTIONS) => {
+  if (!target) {
+    return null;
+  }
+
+  if (typeof target === "string") {
+    return waitForElement(target, options);
+  }
+
+  if (Array.isArray(target)) {
+    for (const candidate of target) {
+      const element = await resolveElementTarget(candidate, options);
+      if (element) {
+        return element;
+      }
+    }
+
+    return null;
+  }
+
+  if (typeof target === "object") {
+    const selectors = [];
+
+    if (typeof target.selector === "string") {
+      selectors.push(target.selector);
+    }
+
+    if (Array.isArray(target.selectors)) {
+      target.selectors
+        .filter((item) => typeof item === "string")
+        .forEach((item) => selectors.push(item));
+    }
+
+    const labelText = typeof target.labelText === "string" ? target.labelText : undefined;
+
+    const directMatch = await waitForSelectorsOrLabel(selectors, labelText, options);
+    if (directMatch) {
+      return directMatch;
+    }
+  }
+
+  return null;
+};
+
+const fillInputValue = async (target, value) => {
+  const element = await resolveElementTarget(target);
+
+  if (!element) {
+    log(`Element not found for target`, target);
+    return false;
+  }
+
+  element.focus();
+  element.value = value ?? "";
+  triggerEvents(element, ["input", "change", "blur"]);
+
+  log("Filled field with value", { target, value });
+  return true;
+};
+
+const selectOptionValue = async (target, value) => {
+  let element = await resolveElementTarget(target);
+
+  if (!element) {
+    log(`Select element not found for target`, target);
+    return false;
+  }
+
+  if (value === undefined || value === null || value === "") {
+    log(`No value provided for select`, target);
+    return true;
+  }
+
+  const normalizedValue = normalizeText(value);
+  const maxAttempts = 6;
+
+  const findMatchingOption = (selectElement) => {
+    const options = Array.from(selectElement?.options || []);
+    return (
+      options.find((item) => {
+        const optionValue = normalizeText(item.value ?? "");
+        const optionText = normalizeText(item.textContent ?? "");
+        return optionValue === normalizedValue || optionText === normalizedValue;
+      }) ||
+      options.find((item) => {
+        const optionValue = normalizeText(item.value ?? "");
+        const optionText = normalizeText(item.textContent ?? "");
+        return optionText.includes(normalizedValue) || normalizedValue.includes(optionText);
+      })
+    );
+  };
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    if (!element) {
+      log("Select element became unavailable, tentative de nouvelle résolution", target);
+      element = await resolveElementTarget(target);
+      if (!element) {
+        await delay(80);
+        continue;
+      }
+    }
+
+    const option = findMatchingOption(element);
+
+    if (option) {
+      element.value = option.value;
+      triggerEvents(element, ["input", "change", "blur"]);
+
+      log("Selected option for field", { target, value: element.value });
+      return true;
+    }
+
+    await delay(100);
+
+    if (!document.contains(element)) {
+      element = null;
+    }
+  }
+
+  log(`Option not found for value: ${value}`, target);
+  return false;
+};
+
+const setCheckboxState = async (target, shouldCheck = true) => {
+  const checkbox = await resolveElementTarget(target);
+
+  if (!checkbox) {
+    log(`Checkbox not found for target`, target);
+    return false;
+  }
+
+  if (checkbox.checked !== shouldCheck) {
+    checkbox.checked = shouldCheck;
+    triggerEvents(checkbox, ["input", "change", "click"]);
+  }
+
+  log("Checkbox field updated", { target, shouldCheck });
+  return true;
+};
+
+const ensureStep = async (stepPromise, errorMessage) => {
+  const result = await stepPromise;
+
+  if (!result) {
+    throw new Error(errorMessage);
+  }
+};
+
+const handleFillForm = async (data = {}) => {
+  log("Received fillForm action", data);
+
+  await ensureStep(
+    setCheckboxState("#choice_2_131_1", true),
+    "Impossible d'activer la saisie manuelle."
+  );
+
+  await ensureStep(
+    fillInputValue("#input_2_127", data.make ?? ""),
+    "Impossible de remplir le champ « Marque »"
+  );
+  await ensureStep(
+    fillInputValue("#input_2_128", data.model ?? ""),
+    "Impossible de remplir le champ « Modèle »"
+  );
+  await ensureStep(
+    fillInputValue("#input_2_129", data.engine ?? ""),
+    "Impossible de remplir le champ « Motorisation »"
+  );
+  if (data.vehicleType) {
+    await ensureStep(
+      selectOptionValue(
+        { selectors: ["#input_2_130", "#input_2_87"], labelText: "Type de véhicule" },
+        data.vehicleType
+      ),
+      "Impossible de sélectionner le type de véhicule."
+    );
+  } else {
+    log("Vehicle type non fourni, étape ignorée.");
+  }
+
+  if (data.vehicleCategory) {
+    await ensureStep(
+      selectOptionValue(
+        { selectors: ["#input_2_90", "#input_2_143"], labelText: "Catégorie" },
+        data.vehicleCategory
+      ),
+      "Impossible de sélectionner la catégorie."
+    );
+  } else {
+    log("Catégorie de véhicule non fournie, étape ignorée.");
+  }
+  try {
+    await ensureStep(
+      selectOptionValue("#input_2_88", data.fuelType || "Diesel"),
+      "Impossible de sélectionner le carburant."
+    );
+  } catch (error) {
+    log("Fuel selection step failed but continuing", error);
+  }
+  await ensureStep(
+    selectOptionValue(
+      {
+        selectors: [
+          "#input_2_142",
+          "#input_2_91",
+          "select[name='input_2_142']",
+          "select[name='input_2_91']",
+        ],
+        labelText: "Usage",
+      },
+      data.usageType || "Particulier"
+    ),
+    "Impossible de sélectionner l'usage."
+  );
+
+  log("Form auto-fill completed");
+};
+
+const registerContentTab = ({ silent = false } = {}) => {
+  try {
+    chrome.runtime.sendMessage({ action: "registerContentTab" }, (response) => {
+      if (chrome.runtime.lastError) {
+        if (!silent) {
+          log("Failed to register content tab", chrome.runtime.lastError);
+        }
+        return;
+      }
+
+      if (!response?.success) {
+        if (!silent) {
+          log("Background did not accept registration", response);
+        }
+        return;
+      }
+
+      if (!silent) {
+        log("Content tab registered with background");
+      }
+    });
+  } catch (error) {
+    if (!silent) {
+      log("Unexpected error while registering content tab", error);
+    }
+  }
+};
+
+registerContentTab();
+setInterval(() => registerContentTab({ silent: true }), 15000);
+document.addEventListener("visibilitychange", () => {
+  if (!document.hidden) {
+    registerContentTab({ silent: true });
+  }
+});
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message?.action === "fillForm") {
+    handleFillForm(message.data)
+      .then(() => {
+        sendResponse({ success: true });
+      })
+      .catch((error) => {
+        log("Auto-fill failed", error);
+        sendResponse({ success: false, error: error?.message || "Remplissage impossible." });
+      });
+
+    return true;
+  }
+
+  return undefined;
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,31 @@
+{
+  "manifest_version": 3,
+  "name": "Yooliz Auto-Fill POC",
+  "version": "1.0.0",
+  "description": "Proof of concept extension to auto-fill Yooliz estimates.",
+  "action": {
+    "default_title": "Test Auto-Fill",
+    "default_popup": "popup.html"
+  },
+  "permissions": ["storage", "identity"],
+  "host_permissions": [
+    "https://*.yooliz.com/liste-des-devis/creer-un-devis/*",
+    "https://sheets.googleapis.com/*"
+  ],
+  "oauth2": {
+    "client_id": "982144274843-9spsvbnctljjojhepu6kl75mas40603s.apps.googleusercontent.com",
+    "scopes": ["https://www.googleapis.com/auth/spreadsheets"]
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://*.yooliz.com/liste-des-devis/creer-un-devis/*"
+      ],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Devis Yooliz</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="popup" aria-live="polite">
+      <h1 class="popup__title">Liste des devis</h1>
+      <p id="status" class="popup__status" role="status"></p>
+      <div class="popup__actions">
+        <button
+          id="clear-filled"
+          class="popup__clear-button"
+          type="button"
+          hidden
+        >
+          Supprimer les devis utilisés
+        </button>
+      </div>
+      <ul id="quotes-list" class="popup__list" aria-label="Devis disponibles"></ul>
+    </main>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,558 @@
+const statusElement = document.getElementById("status");
+const quotesListElement = document.getElementById("quotes-list");
+const clearFilledButton = document.getElementById("clear-filled");
+const storage = chrome?.storage?.local;
+const filledQuotes = new Set();
+const hiddenFilledQuotes = new Set();
+let currentQuotes = [];
+let refreshIntervalId = null;
+let isAutoRefreshing = false;
+
+const REFRESH_INTERVAL_MS = 5000;
+
+const STORAGE_KEYS = {
+  filledQuotes: "yoolizFilledQuotes",
+  hiddenFilledQuotes: "yoolizHiddenFilledQuotes",
+};
+
+const STATUS_CLASSES = ["popup__status--loading", "popup__status--error", "popup__status--success"];
+
+const setStatus = (message = "", type = "info") => {
+  if (!statusElement) {
+    return;
+  }
+
+  statusElement.textContent = message;
+  STATUS_CLASSES.forEach((className) => statusElement.classList.remove(className));
+
+  if (type === "loading") {
+    statusElement.classList.add("popup__status--loading");
+  } else if (type === "error") {
+    statusElement.classList.add("popup__status--error");
+  } else if (type === "success") {
+    statusElement.classList.add("popup__status--success");
+  }
+};
+
+const log = (message, extra) => {
+  if (extra !== undefined) {
+    console.log(`[Popup] ${message}`, extra);
+  } else {
+    console.log(`[Popup] ${message}`);
+  }
+};
+
+const sendRuntimeMessage = (message) =>
+  new Promise((resolve, reject) => {
+    try {
+      chrome.runtime.sendMessage(message, (response) => {
+        if (chrome.runtime.lastError) {
+          reject(chrome.runtime.lastError);
+          return;
+        }
+
+        resolve(response);
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+const getQuoteKey = (quote) => {
+  if (quote?.id) {
+    return `id:${quote.id}`;
+  }
+
+  if (quote?.label) {
+    return `label:${quote.label}`;
+  }
+
+  return JSON.stringify(quote ?? {});
+};
+
+const persistPopupState = () => {
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.set(
+      {
+        [STORAGE_KEYS.filledQuotes]: Array.from(filledQuotes),
+        [STORAGE_KEYS.hiddenFilledQuotes]: Array.from(hiddenFilledQuotes),
+      },
+      () => {
+        if (chrome.runtime.lastError) {
+          console.warn("[Popup] Impossible d'enregistrer l'état", chrome.runtime.lastError);
+        }
+      }
+    );
+  } catch (error) {
+    console.warn("[Popup] Échec de la persistance de l'état", error);
+  }
+};
+
+const restorePopupState = () =>
+  new Promise((resolve) => {
+    if (!storage) {
+      resolve();
+      return;
+    }
+
+    try {
+      storage.get(
+        [STORAGE_KEYS.filledQuotes, STORAGE_KEYS.hiddenFilledQuotes],
+        (result) => {
+          if (chrome.runtime.lastError) {
+            console.warn(
+              "[Popup] Impossible de restaurer l'état précédent",
+              chrome.runtime.lastError
+            );
+            resolve();
+            return;
+          }
+
+          const storedFilled = result?.[STORAGE_KEYS.filledQuotes];
+          const storedHidden = result?.[STORAGE_KEYS.hiddenFilledQuotes];
+
+          if (Array.isArray(storedFilled)) {
+            storedFilled.forEach((key) => filledQuotes.add(key));
+          }
+
+          if (Array.isArray(storedHidden)) {
+            storedHidden.forEach((key) => hiddenFilledQuotes.add(key));
+          }
+
+          updateClearFilledVisibility();
+          renderQuotes();
+          resolve();
+        }
+      );
+    } catch (error) {
+      console.warn("[Popup] Échec de la restauration de l'état", error);
+      resolve();
+    }
+  });
+
+const countFilledQuotesInView = () =>
+  currentQuotes.reduce((count, quote) => {
+    const key = getQuoteKey(quote);
+    if (hiddenFilledQuotes.has(key)) {
+      return count;
+    }
+
+    return filledQuotes.has(key) ? count + 1 : count;
+  }, 0);
+
+const pruneStateForCurrentQuotes = () => {
+  const validKeys = new Set(currentQuotes.map((quote) => getQuoteKey(quote)));
+  let stateChanged = false;
+
+  for (const key of Array.from(filledQuotes)) {
+    if (!validKeys.has(key)) {
+      filledQuotes.delete(key);
+      stateChanged = true;
+    }
+  }
+
+  for (const key of Array.from(hiddenFilledQuotes)) {
+    if (!validKeys.has(key)) {
+      hiddenFilledQuotes.delete(key);
+      stateChanged = true;
+    }
+  }
+
+  if (stateChanged) {
+    persistPopupState();
+  }
+};
+
+const buildQuoteSignature = (quote = {}) =>
+  [
+    getQuoteKey(quote),
+    quote.rowNumber ?? "",
+    quote.make ?? "",
+    quote.model ?? "",
+    quote.engine ?? "",
+    quote.fuelType ?? "",
+    quote.usageType ?? "",
+    quote.vehicleType ?? "",
+    quote.vehicleCategory ?? "",
+  ].join("|");
+
+const haveQuotesChanged = (nextQuotes = []) => {
+  if (!Array.isArray(nextQuotes)) {
+    return false;
+  }
+
+  if (currentQuotes.length !== nextQuotes.length) {
+    return true;
+  }
+
+  const currentSignatures = currentQuotes.map((quote) => buildQuoteSignature(quote)).sort();
+  const nextSignatures = nextQuotes.map((quote) => buildQuoteSignature(quote)).sort();
+
+  for (let index = 0; index < currentSignatures.length; index += 1) {
+    if (currentSignatures[index] !== nextSignatures[index]) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const updateClearFilledVisibility = () => {
+  if (!clearFilledButton) {
+    return;
+  }
+
+  const filledCount = countFilledQuotesInView();
+  const hasFilledQuotes = filledCount > 0;
+  clearFilledButton.hidden = !hasFilledQuotes;
+  clearFilledButton.disabled = !hasFilledQuotes;
+
+  if (!hasFilledQuotes) {
+    clearFilledButton.textContent = "Supprimer les devis utilisés";
+    return;
+  }
+
+  clearFilledButton.textContent =
+    filledCount === 1
+      ? "Supprimer le devis utilisé"
+      : `Supprimer ${filledCount} devis utilisés`;
+};
+
+const sendFillRequest = async (quote) => {
+  const payload = {
+    make: quote.make || "",
+    model: quote.model || "",
+    engine: quote.engine || "",
+    fuelType: quote.fuelType || "",
+    usageType: quote.usageType || "",
+    vehicleType: quote.vehicleType || "",
+    vehicleCategory: quote.vehicleCategory || "",
+  };
+
+  try {
+    const response = await sendRuntimeMessage({
+      action: "fillQuote",
+      data: payload,
+      quoteId: quote.id,
+    });
+
+    if (!response?.success) {
+      throw new Error(response?.error || "Réponse invalide du service");
+    }
+
+    log("Requête de remplissage envoyée", payload);
+    setStatus(`Devis « ${quote.label} » envoyé.`, "success");
+    return true;
+  } catch (error) {
+    console.error("[Popup] Erreur lors de l'envoi de la requête", error);
+    if (
+      error?.message === "Impossible de sélectionner le carburant." ||
+      error?.message === "Impossible de sélectionner l'usage."
+    ) {
+      log(
+        "Le remplissage s'est terminé malgré un échec de sélection de carburant ou d'usage."
+      );
+      setStatus(`Devis « ${quote.label} » envoyé.`, "success");
+      return true;
+    }
+
+    const message = error?.message
+      ? `Erreur lors de l'envoi : ${error.message}`
+      : "Impossible d'envoyer le devis au formulaire.";
+    setStatus(message, "error");
+    return false;
+  }
+};
+
+const createQuoteElement = (quote) => {
+  const item = document.createElement("li");
+  item.className = "popup__list-item";
+
+  const header = document.createElement("div");
+  header.className = "popup__list-header";
+
+  const title = document.createElement("p");
+  title.className = "popup__list-title";
+  title.textContent = quote.label;
+
+  const progress = document.createElement("span");
+  progress.className = "popup__list-progress";
+  progress.setAttribute("role", "progressbar");
+  progress.setAttribute("aria-hidden", "true");
+
+  header.appendChild(title);
+  header.appendChild(progress);
+
+  const meta = document.createElement("p");
+  meta.className = "popup__list-meta";
+  const metaParts = [quote.make, quote.model, quote.engine].filter(Boolean);
+  meta.textContent = metaParts.length > 0 ? metaParts.join(" • ") : "Informations véhicule indisponibles";
+
+  const secondaryMetaParts = [quote.vehicleType, quote.vehicleCategory].filter(Boolean);
+  const secondaryMeta = document.createElement("p");
+  secondaryMeta.className = "popup__list-meta popup__list-meta--secondary";
+  secondaryMeta.textContent =
+    secondaryMetaParts.length > 0 ? secondaryMetaParts.join(" • ") : "";
+
+  const actionButton = document.createElement("button");
+  actionButton.type = "button";
+  actionButton.className = "popup__list-action";
+  actionButton.textContent = "Remplir";
+  let isSending = false;
+  const quoteKey = getQuoteKey(quote);
+  let isFilled = filledQuotes.has(quoteKey);
+
+  const filledIndicator = document.createElement("span");
+  filledIndicator.className = "popup__list-filled-indicator";
+  filledIndicator.textContent = "UTILISÉ";
+  filledIndicator.setAttribute("aria-hidden", "true");
+
+  const actionsRow = document.createElement("div");
+  actionsRow.className = "popup__list-actions";
+  actionsRow.appendChild(actionButton);
+  actionsRow.appendChild(filledIndicator);
+
+  const setLoadingState = (isLoading) => {
+    isSending = isLoading;
+    actionButton.disabled = isLoading || isFilled;
+    item.classList.toggle("popup__list-item--loading", isLoading);
+    if (isLoading) {
+      progress.classList.add("popup__list-progress--visible");
+      progress.setAttribute("aria-hidden", "false");
+      progress.setAttribute("aria-label", `Envoi du devis « ${quote.label} »`);
+    } else {
+      progress.classList.remove("popup__list-progress--visible");
+      progress.setAttribute("aria-hidden", "true");
+      progress.removeAttribute("aria-label");
+    }
+  };
+
+  const setFilledState = (filled) => {
+    isFilled = Boolean(filled);
+    item.classList.toggle("popup__list-item--filled", isFilled);
+    if (isFilled) {
+      actionButton.classList.add("popup__list-action--filled");
+      filledQuotes.add(quoteKey);
+      hiddenFilledQuotes.delete(quoteKey);
+      filledIndicator.classList.add("popup__list-filled-indicator--visible");
+      filledIndicator.setAttribute("aria-hidden", "false");
+    } else {
+      actionButton.classList.remove("popup__list-action--filled");
+      filledQuotes.delete(quoteKey);
+      filledIndicator.classList.remove("popup__list-filled-indicator--visible");
+      filledIndicator.setAttribute("aria-hidden", "true");
+    }
+    actionButton.textContent = "Remplir";
+    actionButton.disabled = isFilled || isSending;
+    persistPopupState();
+    updateClearFilledVisibility();
+  };
+
+  if (isFilled) {
+    setFilledState(true);
+  }
+
+  actionButton.addEventListener("click", async () => {
+    if (isSending) {
+      return;
+    }
+
+    log("Devis sélectionné", quote);
+    setStatus(`Envoi du devis « ${quote.label} »…`, "loading");
+    setLoadingState(true);
+
+    try {
+      const success = await sendFillRequest(quote);
+      if (success) {
+        setFilledState(true);
+      }
+    } finally {
+      setLoadingState(false);
+    }
+  });
+
+  item.appendChild(header);
+  item.appendChild(meta);
+  if (secondaryMetaParts.length > 0) {
+    item.appendChild(secondaryMeta);
+  }
+  item.appendChild(actionsRow);
+
+  return item;
+};
+
+const renderQuotes = () => {
+  if (!quotesListElement) {
+    return;
+  }
+
+  quotesListElement.replaceChildren();
+
+  currentQuotes
+    .filter((quote) => !hiddenFilledQuotes.has(getQuoteKey(quote)))
+    .forEach((quote) => {
+      quotesListElement.appendChild(createQuoteElement(quote));
+    });
+
+  updateClearFilledVisibility();
+};
+
+const setQuotes = (quotes = []) => {
+  currentQuotes = Array.isArray(quotes) ? [...quotes] : [];
+  pruneStateForCurrentQuotes();
+  renderQuotes();
+};
+
+const notifyRemovedQuotes = async (quotes) => {
+  if (!Array.isArray(quotes) || quotes.length === 0) {
+    return { success: true, removed: 0 };
+  }
+
+  const response = await sendRuntimeMessage({
+    action: "removeUsedQuotes",
+    quotes,
+  });
+
+  if (!response?.success) {
+    throw new Error(response?.error || "Le service de suppression a échoué.");
+  }
+
+  return response;
+};
+
+const loadQuotes = async ({
+  forceRefresh = false,
+  silent = false,
+  suppressStatusUpdate = false,
+} = {}) => {
+  if (!silent) {
+    setStatus("Chargement des devis…", "loading");
+  }
+
+  try {
+    const response = await sendRuntimeMessage({
+      action: "getQuotes",
+      forceRefresh,
+    });
+
+    if (!response?.success) {
+      throw new Error(response?.error || "Réponse invalide du service");
+    }
+
+    const quotes = Array.isArray(response.quotes) ? response.quotes : [];
+
+    if (quotes.length === 0) {
+      setQuotes([]);
+      if (!suppressStatusUpdate) {
+        setStatus("Aucun devis disponible.");
+      }
+      return quotes;
+    }
+
+    const quotesChanged = haveQuotesChanged(quotes);
+    setQuotes(quotes);
+
+    if (!silent) {
+      const statusMessage = response.fromCache
+        ? "Devis chargés (cache)."
+        : "Devis chargés depuis Google Sheets.";
+
+      setStatus(statusMessage, "success");
+    } else if (quotesChanged && !suppressStatusUpdate) {
+      setStatus("Liste des devis mise à jour.", "success");
+    }
+
+    return quotes;
+  } catch (error) {
+    console.error("[Popup] Échec du chargement des devis", error);
+    setStatus("Erreur lors de la récupération des devis.", "error");
+    return [];
+  }
+};
+
+const initializePopup = async () => {
+  await restorePopupState();
+  await loadQuotes({ forceRefresh: true });
+  if (refreshIntervalId !== null) {
+    clearInterval(refreshIntervalId);
+  }
+  refreshIntervalId = setInterval(() => {
+    if (isAutoRefreshing) {
+      return;
+    }
+
+    isAutoRefreshing = true;
+    loadQuotes({ forceRefresh: true, silent: true }).finally(() => {
+      isAutoRefreshing = false;
+    });
+  }, REFRESH_INTERVAL_MS);
+};
+
+initializePopup();
+
+window.addEventListener("unload", () => {
+  if (refreshIntervalId !== null) {
+    clearInterval(refreshIntervalId);
+    refreshIntervalId = null;
+  }
+});
+
+if (clearFilledButton) {
+  clearFilledButton.addEventListener("click", async () => {
+    const filledCount = countFilledQuotesInView();
+
+    if (filledCount === 0) {
+      setStatus("Aucun devis rempli à retirer.");
+      return;
+    }
+
+    const filledQuotesInView = currentQuotes.filter((quote) =>
+      filledQuotes.has(getQuoteKey(quote))
+    );
+
+    const filledKeysToHide = filledQuotesInView.map((quote) => getQuoteKey(quote));
+
+    const previousHidden = new Set(hiddenFilledQuotes);
+
+    filledKeysToHide.forEach((key) => hiddenFilledQuotes.add(key));
+
+    renderQuotes();
+    persistPopupState();
+
+    const removalPayload = filledQuotesInView.map((quote) => ({
+      key: getQuoteKey(quote),
+      id: quote.id || "",
+      label: quote.label || "",
+      rowNumber: typeof quote.rowNumber === "number" ? quote.rowNumber : null,
+      raw: quote.raw || null,
+    }));
+
+    setStatus("Suppression des devis utilisés…", "loading");
+
+    try {
+      await notifyRemovedQuotes(removalPayload);
+      await loadQuotes({ forceRefresh: true, silent: true, suppressStatusUpdate: true });
+      const message =
+        filledCount === 1
+          ? "Le devis utilisé a été retiré de la liste."
+          : `${filledCount} devis utilisés ont été retirés de la liste.`;
+      setStatus(message, "success");
+    } catch (error) {
+      console.error("[Popup] Échec de la notification de suppression", error);
+      hiddenFilledQuotes.clear();
+      previousHidden.forEach((key) => hiddenFilledQuotes.add(key));
+      renderQuotes();
+      persistPopupState();
+      setStatus(
+        error?.message
+          ? `Erreur lors de la suppression des devis utilisés : ${error.message}`
+          : "Impossible de notifier la suppression des devis utilisés.",
+        "error"
+      );
+    }
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,241 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #f5f5f5;
+  color: #1a1a1a;
+}
+
+body {
+  margin: 0;
+  padding: 16px;
+  min-width: 260px;
+}
+
+.popup {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.popup__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+.popup__status { 
+  margin: 0;
+  min-height: 1.2rem;
+  font-size: 0.85rem;
+  color: #495057;
+}
+
+.popup__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.popup__clear-button {
+  padding: 6px 12px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #0d6efd;
+  background: transparent;
+  border: 1px solid rgba(13, 110, 253, 0.4);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.popup__clear-button:hover,
+.popup__clear-button:focus {
+  background: rgba(13, 110, 253, 0.08);
+  outline: none;
+}
+
+.popup__clear-button:disabled {
+  color: #6c757d;
+  border-color: rgba(108, 117, 125, 0.4);
+  cursor: not-allowed;
+  background: transparent;
+}
+
+.popup__status--loading {
+  color: #0d6efd;
+}
+
+.popup__status--error {
+  color: #dc3545;
+}
+
+.popup__status--success {
+  color: #198754;
+}
+
+.popup__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.popup__list-item {
+  background: #ffffff;
+  border-radius: 8px;
+  border: 1px solid #dee2e6;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.06);
+}
+
+.popup__list-item--loading {
+  border-color: #0d6efd;
+  box-shadow: 0 2px 6px rgba(13, 110, 253, 0.15);
+}
+
+.popup__list-item:hover,
+.popup__list-item:focus-within {
+  border-color: #0d6efd;
+  box-shadow: 0 2px 6px rgba(13, 110, 253, 0.15);
+}
+
+.popup__list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.popup__list-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: inherit;
+}
+
+
+.popup__list-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.popup__list-filled-indicator {
+  display: none;
+  margin-left: auto;
+  font-size: 1.05rem;
+  font-weight: 800;
+  color: #198754;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.popup__list-filled-indicator--visible {
+  display: inline-flex;
+  align-items: center;
+}
+
+.popup__list-meta {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #6c757d;
+}
+
+.popup__list-meta--secondary {
+  font-size: 0.75rem;
+}
+
+.popup__list-progress {
+  position: relative;
+  width: 72px;
+  height: 4px;
+  border-radius: 999px;
+  background: #e9ecef;
+  overflow: hidden;
+  display: none;
+}
+
+.popup__list-item--filled {
+  background: rgba(25, 135, 84, 0.08);
+  border-color: rgba(25, 135, 84, 0.4);
+}
+
+.popup__list-item--filled .popup__list-title {
+  color: #146c43;
+}
+
+.popup__list-item--filled .popup__list-meta {
+  color: #52735f;
+}
+
+.popup__list-action--filled,
+.popup__list-action--filled:disabled {
+  background: rgba(25, 135, 84, 0.16);
+  color: #146c43;
+  cursor: default;
+  opacity: 1;
+}
+
+.popup__list-action--filled:hover,
+.popup__list-action--filled:focus,
+.popup__list-action--filled:active {
+  background: rgba(25, 135, 84, 0.16);
+}
+
+.popup__list-progress::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(13, 110, 253, 0.2), #0d6efd, rgba(13, 110, 253, 0.2));
+  animation: popupProgress 1.2s linear infinite;
+}
+
+.popup__list-progress--visible {
+  display: block;
+}
+
+@keyframes popupProgress {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
+.popup__list-action {
+  align-self: flex-start;
+  padding: 6px 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: #0d6efd;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.popup__list-action:disabled {
+  cursor: not-allowed;
+  background: #6c757d;
+  opacity: 0.8;
+}
+
+.popup__list-action:hover,
+.popup__list-action:focus {
+  background: #0b5ed7;
+  outline: none;
+}
+
+.popup__list-action:active {
+  background: #0a53be;
+}


### PR DESCRIPTION
## Summary
- replace the Chrome identity token helper with a PKCE-based OAuth 2.0 flow that works with web application client IDs
- persist Google Sheets access and refresh tokens in chrome.storage so deletion calls can refresh automatically before contacting the API
- document the web-client configuration steps and record the provided OAuth client ID in the manifest

## Testing
- not run (extension change; manual verification required in Chrome)

------
https://chatgpt.com/codex/tasks/task_e_68dd47102290832caa3cc50bfffa596e